### PR TITLE
Feat/menu option update

### DIFF
--- a/src/main/java/com/fortest/orderdelivery/app/domain/image/controller/ImageServiceController.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/image/controller/ImageServiceController.java
@@ -1,7 +1,7 @@
 package com.fortest.orderdelivery.app.domain.image.controller;
 
 import com.fortest.orderdelivery.app.domain.image.dto.MenuImageRequestDto;
-import com.fortest.orderdelivery.app.domain.image.dto.MenuImageResponseDto;
+import com.fortest.orderdelivery.app.domain.image.dto.ImageResponseDto;
 import com.fortest.orderdelivery.app.domain.image.service.ImageService;
 import com.fortest.orderdelivery.app.global.dto.CommonDto;
 import java.util.List;
@@ -25,12 +25,12 @@ public class ImageServiceController {
     private final ImageService imageService;
 
     @PostMapping("/menus")
-    public ResponseEntity<CommonDto<MenuImageResponseDto>> registerMenuImage(
+    public ResponseEntity<CommonDto<ImageResponseDto>> registerMenuImage(
         @RequestParam(value = "image-list", required = false)
         List<MultipartFile> multipartFileList) {
-        MenuImageResponseDto responseDto = imageService.registerMenuImage(multipartFileList);
+        ImageResponseDto responseDto = imageService.registerMenuImage(multipartFileList);
 
-        return ResponseEntity.ok(CommonDto.<MenuImageResponseDto>builder()
+        return ResponseEntity.ok(CommonDto.<ImageResponseDto>builder()
             .message("사진 저장 완료")
             .code(HttpStatus.OK.value())
             .data(responseDto)
@@ -38,12 +38,25 @@ public class ImageServiceController {
     }
 
     @PostMapping("/menus/{menuId}")
-    public ResponseEntity<CommonDto<MenuImageResponseDto>> updateMenuImage(
+    public ResponseEntity<CommonDto<ImageResponseDto>> updateMenuImage(
         @RequestParam(value = "image-list", required = false) List<MultipartFile> multipartFileList,
         @PathVariable("menuId") String menuId) {
-        MenuImageResponseDto responseDto = imageService.updateMenuImage(multipartFileList, menuId);
+        ImageResponseDto responseDto = imageService.updateMenuImage(multipartFileList, menuId);
 
-        return ResponseEntity.ok(CommonDto.<MenuImageResponseDto>builder()
+        return ResponseEntity.ok(CommonDto.<ImageResponseDto>builder()
+            .message("사진 추가 저장 완료")
+            .code(HttpStatus.OK.value())
+            .data(responseDto)
+            .build());
+    }
+
+    @PostMapping("/options/{optionId}")
+    public ResponseEntity<CommonDto<ImageResponseDto>> updateMenuOptionImage(
+        @RequestParam(value = "image-list", required = false) List<MultipartFile> multipartFileList,
+        @PathVariable("menuOptionId") String menuOptionId) {
+        ImageResponseDto responseDto = imageService.updateMenuOptionImage(multipartFileList, menuOptionId);
+
+        return ResponseEntity.ok(CommonDto.<ImageResponseDto>builder()
             .message("사진 추가 저장 완료")
             .code(HttpStatus.OK.value())
             .data(responseDto)
@@ -51,11 +64,11 @@ public class ImageServiceController {
     }
 
     @PatchMapping("/menus")
-    public ResponseEntity<CommonDto<MenuImageResponseDto>> deleteImageFromS3(@RequestBody
+    public ResponseEntity<CommonDto<ImageResponseDto>> deleteImageFromS3(@RequestBody
     MenuImageRequestDto menuImageRequestDto) {
-        MenuImageResponseDto responseDto = imageService.deleteImageFromS3(menuImageRequestDto);
+        ImageResponseDto responseDto = imageService.deleteImageFromS3(menuImageRequestDto);
 
-        return ResponseEntity.ok(CommonDto.<MenuImageResponseDto>builder()
+        return ResponseEntity.ok(CommonDto.<ImageResponseDto>builder()
             .message("사진 삭제 완료")
             .code(HttpStatus.OK.value())
             .data(responseDto)

--- a/src/main/java/com/fortest/orderdelivery/app/domain/image/controller/ImageServiceController.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/image/controller/ImageServiceController.java
@@ -53,7 +53,7 @@ public class ImageServiceController {
     @PostMapping("/options/{optionId}")
     public ResponseEntity<CommonDto<ImageResponseDto>> updateMenuOptionImage(
         @RequestParam(value = "image-list", required = false) List<MultipartFile> multipartFileList,
-        @PathVariable("menuOptionId") String menuOptionId) {
+        @PathVariable("optionId") String menuOptionId) {
         ImageResponseDto responseDto = imageService.updateMenuOptionImage(multipartFileList, menuOptionId);
 
         return ResponseEntity.ok(CommonDto.<ImageResponseDto>builder()

--- a/src/main/java/com/fortest/orderdelivery/app/domain/image/dto/ImageResponseDto.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/image/dto/ImageResponseDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MenuImageResponseDto {
+public class ImageResponseDto {
     @JsonProperty("image-id-list")
     List<String> imageIdList;
 }

--- a/src/main/java/com/fortest/orderdelivery/app/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/image/mapper/ImageMapper.java
@@ -1,6 +1,6 @@
 package com.fortest.orderdelivery.app.domain.image.mapper;
 
-import com.fortest.orderdelivery.app.domain.image.dto.MenuImageResponseDto;
+import com.fortest.orderdelivery.app.domain.image.dto.ImageResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuImageMappingResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionImageMappingResponseDto;
 import java.util.List;
@@ -8,8 +8,8 @@ import java.util.List;
 //추후에 Security Filter 생성 후, createBy 등 사용자 정보 넣어주기
 public class ImageMapper {
 
-    public static MenuImageResponseDto toMenuImageResponseDto(List<String> imageIdList) {
-        return MenuImageResponseDto.builder()
+    public static ImageResponseDto toImageResponseDto(List<String> imageIdList) {
+        return ImageResponseDto.builder()
             .imageIdList(imageIdList)
             .build();
     }

--- a/src/main/java/com/fortest/orderdelivery/app/domain/image/repository/ImageQueryRepository.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/image/repository/ImageQueryRepository.java
@@ -12,11 +12,21 @@ public class ImageQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Integer getMaxImageSequence(String menuId) {
+    public Integer getMaxMenuImageSequence(String menuId) {
         Integer result = queryFactory
             .select(image.sequence.max())
             .from(image)
             .where(image.menu.id.eq(menuId))
+            .fetchOne();
+
+        return result == null ? 0 : result;
+    }
+
+    public Integer getMaxMenuOptionImageSequence(String menuOptionId) {
+        Integer result = queryFactory
+            .select(image.sequence.max())
+            .from(image)
+            .where(image.menuOption.id.eq(menuOptionId))
             .fetchOne();
 
         return result == null ? 0 : result;

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/controller/MenuOptionAppController.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/controller/MenuOptionAppController.java
@@ -1,0 +1,33 @@
+package com.fortest.orderdelivery.app.domain.menu.controller;
+
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionAppResponseDto;
+import com.fortest.orderdelivery.app.domain.menu.service.MenuOptionAppService;
+import com.fortest.orderdelivery.app.global.dto.CommonDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/app/menus/options")
+@RequiredArgsConstructor
+public class MenuOptionAppController {
+
+    private final MenuOptionAppService menuOptionAppService;
+
+    @GetMapping
+    public ResponseEntity<CommonDto<MenuOptionAppResponseDto>> getMenuOptionFromApp(
+        @RequestParam(name = "menuOptionId") List<String> menuOptionIdList) {
+        MenuOptionAppResponseDto response = menuOptionAppService.getMenuOptionFromApp(menuOptionIdList);
+
+        return ResponseEntity.ok(CommonDto.<MenuOptionAppResponseDto>builder()
+            .message("메뉴 옵션 객체 응답 완료")
+            .code(HttpStatus.OK.value())
+            .data(response)
+            .build());
+    }
+}

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/controller/MenuOptionServiceController.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/controller/MenuOptionServiceController.java
@@ -1,12 +1,16 @@
 package com.fortest.orderdelivery.app.domain.menu.controller;
 
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionSaveResponseDto;
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionUpdateRequestDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionsSaveRequestDto;
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuSaveResponseDto;
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuUpdateRequestDto;
 import com.fortest.orderdelivery.app.domain.menu.service.MenuOptionService;
 import com.fortest.orderdelivery.app.global.dto.CommonDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,13 +18,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/service/menus")
+@RequestMapping("/api/service")
 @RequiredArgsConstructor
 public class MenuOptionServiceController {
 
     private final MenuOptionService menuOptionService;
 
-    @PostMapping("/{menuId}/options")
+    @PostMapping("/menus/{menuId}/options")
     public ResponseEntity<CommonDto<MenuOptionSaveResponseDto>> saveMenuOption(
         @RequestBody MenuOptionsSaveRequestDto menuOptionsSaveRequestDto,
         @PathVariable("menuId") String menuId
@@ -30,6 +34,20 @@ public class MenuOptionServiceController {
 
         return ResponseEntity.ok(CommonDto.<MenuOptionSaveResponseDto>builder()
             .message("메뉴 옵션 등록 완료")
+            .code(HttpStatus.OK.value())
+            .data(responseDto)
+            .build());
+    }
+
+    @PatchMapping("/options/{optionId}")
+    public ResponseEntity<CommonDto<MenuOptionSaveResponseDto>> updateMenuOption(
+        @RequestBody MenuOptionUpdateRequestDto menuOptionUpdateRequestDto,
+        @PathVariable("optionId") String optionId
+    ) {
+        MenuOptionSaveResponseDto responseDto = menuOptionService.updateMenuOption(menuOptionUpdateRequestDto, optionId);
+
+        return ResponseEntity.ok(CommonDto.<MenuOptionSaveResponseDto>builder()
+            .message("메뉴 옵션 수정 완료")
             .code(HttpStatus.OK.value())
             .data(responseDto)
             .build());

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/dto/MenuOptionAppResponseDto.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/dto/MenuOptionAppResponseDto.java
@@ -1,0 +1,16 @@
+package com.fortest.orderdelivery.app.domain.menu.dto;
+
+import com.fortest.orderdelivery.app.domain.menu.entity.MenuOption;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MenuOptionAppResponseDto {
+    private List<MenuOption> menuOptionList;
+}

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/dto/MenuOptionUpdateRequestDto.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/dto/MenuOptionUpdateRequestDto.java
@@ -1,0 +1,21 @@
+package com.fortest.orderdelivery.app.domain.menu.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MenuOptionUpdateRequestDto {
+    //    @NotBlank(message = "[name:blank]")
+    private String name;
+    private String description;
+    //    @NotBlank(message = "[price:blank]")
+    private Integer price;
+    @JsonProperty("expose-status")
+    private String exposeStatus;
+}

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/entity/Menu.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/entity/Menu.java
@@ -1,5 +1,6 @@
 package com.fortest.orderdelivery.app.domain.menu.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fortest.orderdelivery.app.global.entity.BaseDataEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "p_menu")
 @Entity
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Menu extends BaseDataEntity {
 
     @Id

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/entity/MenuOption.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/entity/MenuOption.java
@@ -35,4 +35,11 @@ public class MenuOption extends BaseDataEntity {
     @Column(length = 30, nullable = false)
     @Enumerated(value = EnumType.STRING)
     private ExposeStatus exposeStatus = ExposeStatus.ONSALE;
+
+    public void updateMenuOption(String name, String description, Integer price, ExposeStatus exposeStatus) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.exposeStatus = exposeStatus;
+    }
 }

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/mapper/MenuMapper.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/mapper/MenuMapper.java
@@ -3,10 +3,12 @@ package com.fortest.orderdelivery.app.domain.menu.mapper;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuAppResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuListGetResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuListGetResponseDto.MenuListDto;
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionAppResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuSaveRequestDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuSaveResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.entity.ExposeStatus;
 import com.fortest.orderdelivery.app.domain.menu.entity.Menu;
+import com.fortest.orderdelivery.app.domain.menu.entity.MenuOption;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
@@ -41,6 +43,12 @@ public class MenuMapper {
     public static MenuAppResponseDto toMenuAppResponseDto(List<Menu> menuList) {
         return MenuAppResponseDto.builder()
             .menuList(menuList)
+            .build();
+    }
+
+    public static MenuOptionAppResponseDto toMenuOptionAppResponseDto(List<MenuOption> menuOptionList) {
+        return MenuOptionAppResponseDto.builder()
+            .menuOptionList(menuOptionList)
             .build();
     }
 }

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/mapper/MenuMapper.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/mapper/MenuMapper.java
@@ -4,6 +4,7 @@ import com.fortest.orderdelivery.app.domain.menu.dto.MenuAppResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuListGetResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuListGetResponseDto.MenuListDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionAppResponseDto;
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionSaveResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuSaveRequestDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuSaveResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.entity.ExposeStatus;
@@ -49,6 +50,12 @@ public class MenuMapper {
     public static MenuOptionAppResponseDto toMenuOptionAppResponseDto(List<MenuOption> menuOptionList) {
         return MenuOptionAppResponseDto.builder()
             .menuOptionList(menuOptionList)
+            .build();
+    }
+
+    public static MenuOptionSaveResponseDto toMenuOptionSaveResponseDto(MenuOption menuOption) {
+        return MenuOptionSaveResponseDto.builder()
+            .optionId(menuOption.getId())
             .build();
     }
 }

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/service/MenuOptionAppService.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/service/MenuOptionAppService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MenuOptionAppService {
 
-    private MenuOptionService menuOptionService;
+    private final MenuOptionService menuOptionService;
 
     public MenuOptionAppResponseDto getMenuOptionFromApp(List<String> menuOptionIdList) {
 

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/service/MenuOptionAppService.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/service/MenuOptionAppService.java
@@ -1,0 +1,28 @@
+package com.fortest.orderdelivery.app.domain.menu.service;
+
+import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionAppResponseDto;
+import com.fortest.orderdelivery.app.domain.menu.entity.Menu;
+import com.fortest.orderdelivery.app.domain.menu.entity.MenuOption;
+import com.fortest.orderdelivery.app.domain.menu.mapper.MenuMapper;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MenuOptionAppService {
+
+    private MenuOptionService menuOptionService;
+
+    public MenuOptionAppResponseDto getMenuOptionFromApp(List<String> menuOptionIdList) {
+
+        List<MenuOption> menuOptionList = new ArrayList<>();
+
+        menuOptionIdList.forEach(id -> {
+            MenuOption menuOption = menuOptionService.getMenuOptionById(id);
+            menuOptionList.add(menuOption);
+        });
+        return MenuMapper.toMenuOptionAppResponseDto(menuOptionList);
+    }
+}

--- a/src/main/java/com/fortest/orderdelivery/app/domain/menu/service/MenuOptionService.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/menu/service/MenuOptionService.java
@@ -2,14 +2,12 @@ package com.fortest.orderdelivery.app.domain.menu.service;
 
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuAppResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuImageMappingRequestDto;
-import com.fortest.orderdelivery.app.domain.menu.dto.MenuImageMappingResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionImageMappingRequestDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionImageMappingResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionSaveResponseDto;
 import com.fortest.orderdelivery.app.domain.menu.dto.MenuOptionsSaveRequestDto;
 import com.fortest.orderdelivery.app.domain.menu.entity.Menu;
 import com.fortest.orderdelivery.app.domain.menu.entity.MenuOption;
-import com.fortest.orderdelivery.app.domain.menu.mapper.MenuMapper;
 import com.fortest.orderdelivery.app.domain.menu.mapper.MenuOptionMapper;
 import com.fortest.orderdelivery.app.domain.menu.repository.MenuOptionRepository;
 import com.fortest.orderdelivery.app.global.dto.CommonDto;
@@ -18,7 +16,6 @@ import com.fortest.orderdelivery.app.global.exception.NotFoundException;
 import com.fortest.orderdelivery.app.global.util.MessageUtil;
 import java.time.Duration;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +23,6 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
@@ -160,5 +156,11 @@ public class MenuOptionService {
                     messageUtil.getMessage("api.call.server-error"));
             }
         }
+    }
+
+    public MenuOption getMenuOptionById(String menuOptionId) {
+        return menuOptionRepository.findById(menuOptionId).orElseThrow(
+            () -> new NotFoundException(
+                messageUtil.getMessage("not-found.menu.option")));
     }
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 메뉴 옵션 이미지 수정 기능 추가
    - 메뉴 옵션 DB에 존재 여부 확인 기능 추가
    - 메뉴 옵션 수정 기능 추가
## 코멘트
- menu와 menuOption이 manyToOne 연관관계를 가지고 있어서 메뉴 옵션 DB에 존재 여부 확인 기능 로직에서 MenuOption를 응답해줄 때 LazyInitializationException가 발생했습니다. 
- MenuOption 객체가 필요해서 Dto로 해결하진 못하고 대신 Menu Entity에 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"}) 달아주어 해결했습니다.