### PR TITLE
[fix] : paging sort 항목  toUpperCase 적용

### DIFF
--- a/src/main/java/com/fortest/orderdelivery/app/global/util/JpaUtil.java
+++ b/src/main/java/com/fortest/orderdelivery/app/global/util/JpaUtil.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import java.util.Locale;
+
 public class JpaUtil {
 
     /**
@@ -18,6 +20,7 @@ public class JpaUtil {
     public static PageRequest getNormalPageable(Integer page, Integer size, String orderby, String sort) {
 
         Sort sortAndOrderBy = Sort.by(OrderBy.from(orderby).fieldName);
+        sort = sort.toUpperCase(Locale.ROOT);
         sortAndOrderBy = "ASC".equals(sort) ? sortAndOrderBy.ascending() : sortAndOrderBy.descending() ;
 
         return PageRequest.of(page - 1 , getUsableSize(size), sortAndOrderBy);


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    -  paging sort 항목 대문자만 옳은 값으로 인식 -> 이외는 모두 DESC 처리 

- **to-be**
    - paging sort 항목  toUpperCase 적용 
    - 따라서 대소문자는 비교 후 적용 
    - 이외 값은 DESC 로 처리

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)