### PR TITLE
[fix] : store/{storeId}/menus/valid POST 변경, store app valid, 권한체크 제거

### DIFF
--- a/src/main/java/com/fortest/orderdelivery/app/domain/order/dto/StoreMenuValidRequestDto.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/order/dto/StoreMenuValidRequestDto.java
@@ -1,14 +1,12 @@
 package com.fortest.orderdelivery.app.domain.order.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@ToString // 로깅을 위해 추가
 @Getter
 @Builder
 @AllArgsConstructor
@@ -18,6 +16,7 @@ public class StoreMenuValidRequestDto {
     @JsonProperty("menu-list")
     private List<MenuDto> menuList = new ArrayList<>();
 
+    @ToString // 로깅을 위해 추가
     @Getter
     @Builder
     @AllArgsConstructor
@@ -32,6 +31,7 @@ public class StoreMenuValidRequestDto {
         }
     }
 
+    @ToString // 로깅을 위해 추가
     @Getter
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/fortest/orderdelivery/app/domain/store/controller/StoreAppController.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/store/controller/StoreAppController.java
@@ -6,13 +6,10 @@ import com.fortest.orderdelivery.app.domain.store.dto.StoreMenuValidResponseDto;
 import com.fortest.orderdelivery.app.domain.store.service.StoreAppService;
 import com.fortest.orderdelivery.app.global.dto.CommonDto;
 import com.fortest.orderdelivery.app.global.util.MessageUtil;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,12 +23,8 @@ public class StoreAppController {
     private final MessageUtil messageUtil;
     private final StoreAppService storeAppService;
 
-    @PreAuthorize("hasRole('OWNER')")
     @GetMapping("/{storeId}")
-    public ResponseEntity<CommonDto<StoreCheckResponseDto>> getStoreCheck(
-            @Valid @Size(min = 1, max = 50) @PathVariable("storeId") String storeId) {
-
-        log.info(storeId);
+    public ResponseEntity<CommonDto<StoreCheckResponseDto>> getStoreCheck(@PathVariable("storeId") String storeId) {
 
         StoreCheckResponseDto storeCheckResponseDto = storeAppService.getStoreCheck(storeId);
 
@@ -43,11 +36,9 @@ public class StoreAppController {
                 .build());
     }
 
-    @PreAuthorize("hasRole('OWNER')")
-    @GetMapping("/{storeId}/menus/valid")
-    public ResponseEntity<CommonDto<StoreMenuValidResponseDto>> getStoreMenuValid(
-            @Valid @Size(min = 1, max = 50) @PathVariable("storeId") String storeId,
-            @RequestParam("data") StoreMenuValidRequestDto requestDto) {
+    @PostMapping("/{storeId}/menus/valid")
+    public ResponseEntity<CommonDto<StoreMenuValidResponseDto>> getStoreMenuValid(@PathVariable("storeId") String storeId,
+                                                                                  @RequestBody StoreMenuValidRequestDto requestDto) {
         StoreMenuValidResponseDto responseDto = storeAppService.getStoreMenuValid(storeId, requestDto);
         return ResponseEntity.ok(CommonDto.<StoreMenuValidResponseDto>builder()
                 .message(messageUtil.getSuccessMessage())

--- a/src/main/java/com/fortest/orderdelivery/app/domain/store/dto/StoreMenuValidRequestDto.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/store/dto/StoreMenuValidRequestDto.java
@@ -2,21 +2,21 @@ package com.fortest.orderdelivery.app.domain.store.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
+@ToString // 로깅을 위해 추가
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class StoreMenuValidRequestDto {
+
     @JsonProperty("menu-list")
     private List<MenuDto> menuList;
 
+    @ToString // 로깅을 위해 추가
     @Builder
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/fortest/orderdelivery/app/global/gateway/ApiGateway.java
+++ b/src/main/java/com/fortest/orderdelivery/app/global/gateway/ApiGateway.java
@@ -273,28 +273,23 @@ public class ApiGateway {
      * @param
      * @return CommonDto<StoreMenuValidResDto> : 요청 실패 시 null
      */
-    public StoreMenuValidResponseDto getValidStoreMenuFromApp(String storeId,
-        StoreMenuValidRequestDto validReqDto) {
+    public StoreMenuValidResponseDto getValidStoreMenuFromApp(String storeId, StoreMenuValidRequestDto validReqDto) {
         String targetUrl = STORE_VALID_APP_URL
             .replace("{host}", "localhost")
             .replace("{port}", "8082")
             .replace("{storeId}", storeId);
 
         // 요청 파라미터 생성
-        JSONObject paramObject = new JSONObject(validReqDto);
-        Map<String, String> queryParam = Map.of(
-            "data", paramObject.toString()
-        );
-
-        CommonDto<StoreMenuValidResponseDto> commonResponse = webClient.get()
-            .uri(targetUrl, queryParam)
+        CommonDto<StoreMenuValidResponseDto> commonResponse = webClient.post()
+            .uri(targetUrl)
+            .bodyValue(validReqDto)
             .header(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .retrieve()
             .bodyToMono(new ParameterizedTypeReference<CommonDto<StoreMenuValidResponseDto>>() {
             })
             .retryWhen(Retry.fixedDelay(3, Duration.ofSeconds(2))) //에러 발생 시 2초 간격으로 최대 3회 재시도
             .onErrorResume(throwable -> {
-                log.error("Fail : {}, {}", targetUrl, queryParam, throwable);
+                log.error("Fail : {}, {}", targetUrl, validReqDto, throwable);
                 return Mono.empty();
             })
             .block();


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - StoreAppController 메서드에 유저의 권한 체크 로직 존재 
    - StoreAppController 메서드 파라미터에 Valid 항목 존재 
    - store/{storeId}/menus/valid 메서드가 기존 GET요청 수신 
    - store/{storeId}/menus/valid 메서드의 파라미터가 쿼리 파라미터로 수신

- **to-be**
    -  store/{storeId}/menus/valid POST 변경
    - store/{storeId}/menus/valid 메서드의 파라미터가 RequestBody 로 수신
    - store app valid, 
    - 권한체크 제거

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)