### PR TITLE
[fix] : jwt 인가 필터 app 분기처리 변경, 시큐리티 허용 url menus 추가

### DIFF
--- a/src/main/java/com/fortest/orderdelivery/app/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/fortest/orderdelivery/app/global/config/WebSecurityConfig.java
@@ -77,6 +77,7 @@ public class WebSecurityConfig {
                     .requestMatchers("/api/service/users/protected-resource").authenticated()
                     .requestMatchers("/api/service/areas/**").authenticated()
                     .requestMatchers("/api/app/users/*").permitAll()
+                    .requestMatchers("/api/app/menus/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/app/orders/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/app/stores/{storeId}").permitAll()
 //                   .requestMatchers("/api/service/users/refresh").permitAll()

--- a/src/main/java/com/fortest/orderdelivery/app/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/fortest/orderdelivery/app/global/filter/JwtAuthorizationFilter.java
@@ -82,9 +82,15 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 return;
             }
         } else {
-            log.error("Access Token이 요청 헤더에 없음");
-            sendJsonResponse(res, HttpStatus.UNAUTHORIZED, "access.token.missing", null);
+            int i = requestURI.lastIndexOf(REPOSITORY_FIND_URL+APP_URL_SUFFIX);
+            //  URL: /api/api 로 시작하지 않는 경우
+            if (i == -1) {
+                log.error("Access Token이 요청 헤더에 없음 : requestURI = {}", requestURI);
+                sendJsonResponse(res, HttpStatus.UNAUTHORIZED, "access.token.missing", null);
+                return;
+            }
         }
+        log.info("다음 필터 실행");
         // 다음 필터 실행
         filterChain.doFilter(req, res);
     }


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - 필터에서 getWriter() has already been called for this res 발생
    - 시큐리티 허용 url /api/app/menus 없음

- **to-be**
    - jwt 인가 필터 app 분기처리 변경
    - 시큐리티 허용 url : /api/app/menus 추가

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)