### PR TITLE
[fix] : 가게 목록 조회 불가 문제 수정

### DIFF
--- a/src/main/java/com/fortest/orderdelivery/app/domain/store/controller/StoreServiceController.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/store/controller/StoreServiceController.java
@@ -7,14 +7,16 @@ import com.fortest.orderdelivery.app.global.security.UserDetailsImpl;
 import com.fortest.orderdelivery.app.global.util.MessageUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-
+@Slf4j
 @RestController
 @Validated
 @RequestMapping("/api/service")
@@ -41,6 +43,7 @@ public class StoreServiceController {
 
     @GetMapping("/stores/search")
     public ResponseEntity<CommonDto<StoreSearchResponseDto>> searchStore(
+            @Nullable @RequestParam("category-id") String categoryId,
             @Valid StoreSearchRequestDto requestDto
     ) {
         StoreSearchResponseDto storeSearchResponseDto = storeService.searchStore(
@@ -49,7 +52,7 @@ public class StoreServiceController {
                 requestDto.getOrderby(),
                 requestDto.getSort(),
                 requestDto.getSearch(),
-                requestDto.getCategoryId(),
+                categoryId,
                 requestDto.getCity(),
                 requestDto.getDistrict(),
                 requestDto.getStreet()

--- a/src/main/java/com/fortest/orderdelivery/app/domain/store/dto/StoreSearchRequestDto.java
+++ b/src/main/java/com/fortest/orderdelivery/app/domain/store/dto/StoreSearchRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
+@ToString
 @Builder
 @Getter
 @Setter
@@ -14,7 +15,7 @@ public class StoreSearchRequestDto {
 
     @Positive(message = "page 값은 음수일 수 없습니다.")
     private Integer page;
-    @Positive(message = "page 값은 음수일 수 없습니다.")
+    @Positive(message = "size 값은 음수일 수 없습니다.")
     private Integer size;
     @Pattern(regexp = "CREATED|UPDATED", message = "orderby 는 CREATED, UPDATED 만 허용합니다.")
     private String orderby;
@@ -23,8 +24,6 @@ public class StoreSearchRequestDto {
 
     @Size(max = 100)
     private String search;
-
-    private String categoryId;
 
     @Size(min = 1, max = 50)
     private String city;

--- a/src/main/java/com/fortest/orderdelivery/app/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/fortest/orderdelivery/app/global/config/WebSecurityConfig.java
@@ -83,6 +83,7 @@ public class WebSecurityConfig {
                     .requestMatchers("/api/service/areas/**").authenticated()
                     .requestMatchers("/api/app/users/*").permitAll()
                     .requestMatchers("/api/app/menus/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/service/stores/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/service/categories").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/app/orders/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/app/deliveries/**").permitAll()

--- a/src/main/java/com/fortest/orderdelivery/app/global/util/JpaUtil.java
+++ b/src/main/java/com/fortest/orderdelivery/app/global/util/JpaUtil.java
@@ -20,9 +20,14 @@ public class JpaUtil {
     public static PageRequest getNormalPageable(Integer page, Integer size, String orderby, String sort) {
 
         Sort sortAndOrderBy = Sort.by(OrderBy.from(orderby).fieldName);
-        sort = sort.toUpperCase();
+        sort = sort != null ? sort.toUpperCase() : "DESC";
         sortAndOrderBy = "ASC".equals(sort) ? sortAndOrderBy.ascending() : sortAndOrderBy.descending() ;
-
+        if (page == null) {
+            page = 1;
+        }
+        if (size == null) {
+            size = 10;
+        }
         return PageRequest.of(page - 1 , getUsableSize(size), sortAndOrderBy);
     }
 


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
    - 가게 목록 조회 시 category-id 가 null 이 나타나는 현상 -> 조회 불가 문제 발생 

- **to-be**
    - 가게 목록 조회 불가 문제 수정

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)